### PR TITLE
Make it compile with CLANG.

### DIFF
--- a/src/math_funcs.hpp
+++ b/src/math_funcs.hpp
@@ -19,6 +19,7 @@
 #include <cmath>
 #include <algorithm>
 #include <type_traits>
+#include <stdint.h>
 
 template<typename T>
 std::enable_if_t<std::is_floating_point_v<T>, T> log_interp(T a, T b, T t)

--- a/src/waveform_config.hpp.in
+++ b/src/waveform_config.hpp.in
@@ -3,8 +3,8 @@
 #cmakedefine DECORATE_SIMD_FUNCS
 
 #ifdef DECORATE_SIMD_FUNCS
-#define DECORATE_AVX2 __attribute__ ((__target__ ("avx2", "fma")))
-#define DECORATE_AVX __attribute__ ((__target__ ("avx", "fma")))
+#define DECORATE_AVX2 __attribute__ ((__target__ ("avx2,fma")))
+#define DECORATE_AVX __attribute__ ((__target__ ("avx,fma")))
 #define DECORATE_SSE2 __attribute__ ((__target__ ("sse2")))
 #define DECORATE_SSE41 __attribute__ ((__target__ ("sse4.1")))
 #else


### PR DESCRIPTION
- Import stdint to ensure intmax_t is defined
- Change the syntax of the target attribute to use a single option


Clang workaround for #9 