### PR TITLE
add range mode for audio meter

### DIFF
--- a/data/gradient.effect
+++ b/data/gradient.effect
@@ -1,9 +1,12 @@
 uniform float4x4 ViewProj;
 uniform float4 color_base = {1.0, 1.0, 1.0, 1.0};
+uniform float4 color_middle = {1.0, 1.0, 1.0, 1.0};
 uniform float4 color_crest = {1.0, 1.0, 1.0, 1.0};
 uniform float grad_center = 0.0;
 uniform float grad_height = 0.0;
 uniform float grad_offset = 0.0;
+uniform float range_middle = 0.69;  // -20dB when floor is -65dB
+uniform float range_crest = 0.86;   //  -9dB when floor is -65dB
 
 uniform float graph_width = 0.0;
 uniform float graph_height = 0.0;
@@ -68,14 +71,12 @@ float4 PSGradient(VertGrad vert_in) : TARGET
 
 float4 PSRange(VertGrad vert_in) : TARGET
 {
-    float4 color = float4(1.0, 0.0, 0.0, 1.0);  // Default to red
-    
-    if (vert_in.tex.y < 0.75)
-        color = float4(0.0, 1.0, 0.0, 1.0);  // Green
-    else if (vert_in.tex.y < 0.9)
-        color = float4(1.0, 1.0, 0.0, 1.0);  // Yellow
-    
-    return color;
+    float ratio = 1.0 - saturate((distance(vert_in.tex.y, grad_center) - grad_offset) / grad_height);
+    if (ratio > range_middle)
+        return color_base;  // Green
+    else if (ratio < range_crest)
+        return color_crest;  // Red
+	return color_middle;  // Yellow
 }
 
 technique Solid

--- a/data/gradient.effect
+++ b/data/gradient.effect
@@ -66,6 +66,18 @@ float4 PSGradient(VertGrad vert_in) : TARGET
 	return lerp(color_base, color_crest, lerp_t);
 }
 
+float4 PSRange(VertGrad vert_in) : TARGET
+{
+    float4 color = float4(1.0, 0.0, 0.0, 1.0);  // Default to red
+    
+    if (vert_in.tex.y < 0.75)
+        color = float4(0.0, 1.0, 0.0, 1.0);  // Green
+    else if (vert_in.tex.y < 0.9)
+        color = float4(1.0, 1.0, 0.0, 1.0);  // Yellow
+    
+    return color;
+}
+
 technique Solid
 {
 	pass
@@ -83,6 +95,16 @@ technique Gradient
 		pixel_shader  = PSGradient(vert_in);
 	}
 }
+
+technique Range
+{
+    pass
+    {
+        vertex_shader = VSGradient(vert_in);
+        pixel_shader  = PSRange(vert_in);
+    }
+}
+
 
 technique Radial
 {

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -16,6 +16,7 @@ line="Line"
 solid="Solid"
 gradient="Gradient"
 pulse="Pulse"
+range="Range"
 
 pulse_mode="Pulse Mode"
 peak_magnitude="Peak Magnitude"

--- a/data/locale/en-US.ini
+++ b/data/locale/en-US.ini
@@ -80,8 +80,11 @@ exp_moving_avg="Exponential Moving Average"
 fast_peaks="Fast Peaks"
 
 color_base="Base Color"
+color_middle="Middle Color"
 color_crest="Crest Color"
 grad_ratio="Gradient Ratio"
+range_middle="Middle Range"
+range_crest="Crest Range"
 
 display_mode="Display Mode"
 curve="Curve"

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -103,8 +103,11 @@ static inline bool p_equ(const char *s1, const char *s2) { return std::strcmp(s1
 #define P_FAST_PEAKS        "fast_peaks"
 
 #define P_COLOR_BASE        "color_base"
+#define P_COLOR_MIDDLE      "color_middle"
 #define P_COLOR_CREST       "color_crest"
 #define P_GRAD_RATIO        "grad_ratio"
+#define P_RANGE_MIDDLE      "range_middle"
+#define P_RANGE_CREST       "range_crest"
 
 #define P_DISPLAY_MODE      "display_mode"
 #define P_CURVE             "curve"

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -42,6 +42,7 @@ static inline bool p_equ(const char *s1, const char *s2) { return std::strcmp(s1
 #define P_SOLID             "solid"
 #define P_GRADIENT          "gradient"
 #define P_PULSE             "pulse"
+#define P_RANGE             "range"
 
 #define P_PULSE_MODE        "pulse_mode"
 #define P_PEAK_MAG          "peak_magnitude"

--- a/src/source.cpp
+++ b/src/source.cpp
@@ -404,6 +404,7 @@ namespace callbacks {
         obs_property_list_add_string(renderlist, T(P_SOLID), P_SOLID);
         obs_property_list_add_string(renderlist, T(P_GRADIENT), P_GRADIENT);
         obs_property_list_add_string(renderlist, T(P_PULSE), P_PULSE);
+        obs_property_list_add_string(renderlist, T(P_RANGE), P_RANGE);
         auto pulselist = obs_properties_add_list(props, P_PULSE_MODE, T(P_PULSE_MODE), OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_STRING);
         obs_property_list_add_string(pulselist, T(P_PEAK_MAG), P_PEAK_MAG);
         obs_property_list_add_string(pulselist, T(P_PEAK_FREQ), P_PEAK_FREQ);
@@ -413,8 +414,9 @@ namespace callbacks {
         obs_property_set_modified_callback(renderlist, [](obs_properties_t *props, [[maybe_unused]] obs_property_t *property, obs_data_t *settings) -> bool {
             auto grad = p_equ(obs_data_get_string(settings, P_RENDER_MODE), P_GRADIENT);
             auto pulse = p_equ(obs_data_get_string(settings, P_RENDER_MODE), P_PULSE);
-            obs_property_set_enabled(obs_properties_get(props, P_COLOR_CREST), grad || pulse);
-            set_prop_visible(props, P_GRAD_RATIO, grad || pulse);
+            auto range = p_equ(obs_data_get_string(settings, P_RENDER_MODE), P_RANGE);
+            obs_property_set_enabled(obs_properties_get(props, P_COLOR_CREST), grad || pulse || range);
+            set_prop_visible(props, P_GRAD_RATIO, grad || pulse || range);
             set_prop_visible(props, P_PULSE_MODE, pulse);
             return true;
             });
@@ -570,6 +572,8 @@ void WAVSource::get_settings(obs_data_t *settings)
         m_render_mode = RenderMode::GRADIENT;
     else if(p_equ(rendermode, P_PULSE))
         m_render_mode = RenderMode::PULSE;
+    else if(p_equ(rendermode, P_RANGE))
+        m_render_mode = RenderMode::RANGE;
     else
         m_render_mode = RenderMode::SOLID;
 
@@ -1583,8 +1587,12 @@ gs_technique_t *WAVSource::get_shader_tech()
     const char *techname;
     if(m_radial)
         techname = (m_render_mode == RenderMode::GRADIENT) ? "RadialGradient" : "Radial";
+    else if(m_render_mode == RenderMode::GRADIENT)
+        techname = "Gradient";
+    else if(m_render_mode == RenderMode::RANGE)
+        techname = "Range";
     else
-        techname = (m_render_mode == RenderMode::GRADIENT) ? "Gradient" : "Solid";
+        techname = "Solid";
     return gs_effect_get_technique(m_shader, techname);
 }
 

--- a/src/source.hpp
+++ b/src/source.hpp
@@ -62,7 +62,8 @@ enum class RenderMode
     LINE,
     SOLID,
     GRADIENT,
-    PULSE
+    PULSE,
+    RANGE
 };
 
 enum class PulseMode

--- a/src/source.hpp
+++ b/src/source.hpp
@@ -165,8 +165,11 @@ protected:
     int m_ceiling = 0;
     float m_gravity = 0.0f;
     float m_grad_ratio = 1.0f;
+    int m_range_middle = -20;
+    int m_range_crest = -9;
     bool m_fast_peaks = false;
     vec4 m_color_base{ {{1.0, 1.0, 1.0, 1.0}} };
+    vec4 m_color_middle{ {{1.0, 1.0, 1.0, 1.0}} };
     vec4 m_color_crest{ {{1.0, 1.0, 1.0, 1.0}} };
     float m_slope = 0.0f;
     bool m_log_scale = true;


### PR DESCRIPTION
Hi, I am trying to create audio meter similar to sound mixer in obs and other software: green, yellow, red.
In obs log there is shader compilation problem, but I dont see problem. Could you help me?
```
10:00:21.005: Error compiling shader:
10:00:21.005: ERROR: 0:35: Use of undeclared identifier 'vert'
10:00:21.005: ERROR: 0:37: Use of undeclared identifier 'vert'
10:00:21.005: 
10:00:21.005: 
10:00:21.005: device_pixelshader_create (GL) failed
10:00:21.005: Pass (0) <> missing pixel shader!
... other logs
10:00:21.112: effect_setval_inline: invalid param
10:00:21.112: No vertex shader specified
10:00:21.112: device_draw (GL) failed
```
Maybe I am not properly reinstalling new compilation?
Thanks