### PR TITLE
Fix shaders failing to compile with Metal renderer

### DIFF
--- a/data/gradient.effect
+++ b/data/gradient.effect
@@ -65,13 +65,13 @@ float4 PSSolid(VertInOut vert_in) : TARGET
 
 float4 PSGradient(VertGrad vert_in) : TARGET
 {
-    float lerp_t = saturate((distance(vert_in.tex.y, grad_center) - grad_offset) / grad_height);
+    float lerp_t = saturate((abs(vert_in.tex.y - grad_center) - grad_offset) / grad_height);
 	return lerp(color_base, color_crest, lerp_t);
 }
 
 float4 PSRange(VertGrad vert_in) : TARGET
 {
-    float ratio = 1.0 - saturate((distance(vert_in.tex.y, grad_center) - grad_offset) / grad_height);
+    float ratio = 1.0 - saturate((abs(vert_in.tex.y - grad_center) - grad_offset) / grad_height);
     if (ratio > range_middle)
         return color_base;  // Green
     else if (ratio < range_crest)


### PR DESCRIPTION
Fixes #85.

## Root cause
The Metal Shading Language has no scalar overload of `distance()` — only `float2/3/4` (and `half` variants). OBS's Metal backend (`libobs-metal`) transpiles effect-HLSL intrinsics verbatim, so `PSGradient` and `PSRange` fail to compile with:

```
program_source:19:30: error: call to 'distance' is ambiguous
    float lerp_t = saturate((distance(vert_in.tex.y, uniforms.grad_center) - uniforms.grad_offset) / uniforms.grad_height);
```

One failed shader makes `gs_effect_create_from_file` return NULL for the whole effect, so *every* technique (including Solid) stops rendering — matching the "no visual in any mode" symptom. The OBS log only shows the generic `MTLDevice failed to create shader library and function`; I recovered the real MTLCompiler error by instrumenting `MetalShader.swift` in a local libobs-metal build.

## Fix
Replace scalar `distance(a, b)` with `abs(a - b)` in `PSGradient` and `PSRange`. Semantically identical for scalars and valid in HLSL, GLSL, and MSL, so D3D11/OpenGL behavior is unchanged.

## Verification
macOS 26.4, Apple Silicon, OBS 32.1.2 with `Renderer=Metal`:
- Before: 4× `device_vertexshader_create: Device error compiling shader`, `Pass (0) <> missing pixel shader!`, per-frame `effect_setval_inline: invalid param` spam, source screenshot has 0 painted pixels.
- After: zero shader errors in the log; waveform renders correctly in mono and stereo (checked Gradient/Range paths; stereo draws both channels independently).

Everything else in `gradient.effect` transpiles cleanly on 32.1.2 (uniform default initializers, `bool` uniform, `mul()`, scalar `saturate`/`lerp`, all six techniques, GS_TRISTRIP/LINESTRIP/TRIS draws).